### PR TITLE
Fix runaway scrolling in ScrollManager

### DIFF
--- a/src/managers/ScrollManager.ts
+++ b/src/managers/ScrollManager.ts
@@ -102,16 +102,31 @@ export default class ScrollManager {
       return; // Prevent conflicting actions
     }
 
+    let changed = false;
+
     // Load older messages if near the top
     if (topTrigger) {
-      Logger.debug("ScrollManager", "Near the top. Attempting to load older messages...");
-      this.chatManager.scrollWindowUp();
+      Logger.debug(
+        "ScrollManager",
+        "Near the top. Attempting to load older messages..."
+      );
+      changed ||= this.chatManager.scrollWindowUp();
     }
 
     // Load newer messages if near the bottom
     if (bottomTrigger) {
-      Logger.debug("ScrollManager", "Near the bottom. Attempting to load newer messages...");
-      this.chatManager.scrollWindowDown();
+      Logger.debug(
+        "ScrollManager",
+        "Near the bottom. Attempting to load newer messages..."
+      );
+      changed ||= this.chatManager.scrollWindowDown();
+    }
+
+    if (changed) {
+      window.disableAutoScroll = true;
+      window.setTimeout(() => {
+        window.disableAutoScroll = false;
+      }, 50);
     }
 
     // Update the scroll button visibility


### PR DESCRIPTION
## Summary
- gate scroll window changes with a cooldown
- disable auto scroll for a short time after adding or removing messages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f4a75a0ac8327a52e5ae96ec77f24