### PR TITLE
Fix overlay toggle and maintain scroll

### DIFF
--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -74,3 +74,15 @@ chrome.runtime.onMessage.addListener(handleMessages);
 lifeCycleManager?.register((): void => {
   chrome.runtime.onMessage.removeListener(handleMessages);
 });
+
+// Fallback keyboard shortcut for toggling the overlay directly in the page
+const keydownHandler = (e: KeyboardEvent): void => {
+  if (e.ctrlKey && e.shiftKey && (e.key === "Y" || e.key === "y")) {
+    e.preventDefault();
+    virtualiser.toggleOverlay();
+  }
+};
+window.addEventListener("keydown", keydownHandler);
+lifeCycleManager?.register((): void => {
+  window.removeEventListener("keydown", keydownHandler);
+});

--- a/src/managers/VirtualChatManager.ts
+++ b/src/managers/VirtualChatManager.ts
@@ -104,6 +104,15 @@ export default class VirtualChatManager {
     const prevLowest: number = this.lowestIndex;
     const prevHighest: number = this.highestIndex;
 
+    const container: Element | null = this.getConversationContainer();
+    const referenceNode: HTMLElement | undefined = this.allTurns[prevLowest];
+    let refTopBefore = 0;
+    if (container && referenceNode) {
+      const containerRect = (container as HTMLElement).getBoundingClientRect();
+      const refRect = referenceNode.getBoundingClientRect();
+      refTopBefore = refRect.top - containerRect.top;
+    }
+
     // Snap the requested indices to the edges if they are too large or small.
     const maxIndex = this.allTurns.length - 1;
     if (requestIndexLow < 0) {
@@ -117,6 +126,16 @@ export default class VirtualChatManager {
     this.lowestIndex = requestIndexLow;
     this.highestIndex = requestIndexHigh;
     this.updateDOM();
+
+    if (container && referenceNode) {
+      const containerRect = (container as HTMLElement).getBoundingClientRect();
+      const refRect = referenceNode.getBoundingClientRect();
+      const refTopAfter = refRect.top - containerRect.top;
+      const delta = refTopAfter - refTopBefore;
+      if (delta !== 0) {
+        (container as HTMLElement).scrollTop += delta;
+      }
+    }
 
     const isChanged = this.lowestIndex !== prevLowest || this.highestIndex !== prevHighest;
     if (isChanged) Logger.debug("VirtualChatManager", `Window changed: lowest=${this.lowestIndex}, highest=${this.highestIndex}`);


### PR DESCRIPTION
## Summary
- add fallback `keydown` listener in content script so Ctrl+Shift+Y always toggles the debug overlay
- keep scroll position stable when older messages are revealed

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND])*

------
https://chatgpt.com/codex/tasks/task_e_684c3f2a121483279f013899667b562a